### PR TITLE
close client connection to monitor db when done

### DIFF
--- a/action.py
+++ b/action.py
@@ -48,6 +48,7 @@ def get_action_service():
     monitordb_connection, monitordb_table = luigiDBInit()
     select_query = select([monitordb_table]).order_by(desc("last_updated"))
     select_result = monitordb_connection.execute(select_query)
+    monitordb_connection.close()
     result_list = [dict(row) for row in select_result]
     return jsonify(result_list)
 

--- a/luigi-interface/monitor.py
+++ b/luigi-interface/monitor.py
@@ -239,3 +239,5 @@ for job in result_list:
                         monitordb_table.c.status != 'FAILED'))).\
             values(status='JOB NOT FOUND')
         exec_result = monitordb_connection.execute(stmt)
+monitordb_connection.close()
+


### PR DESCRIPTION
close client connection to monitor db when done
otherwise all client connections will be used up and the action service will not load