### PR TITLE
Include the "aliases" field in the file information

### DIFF
--- a/config/mapping_config.json
+++ b/config/mapping_config.json
@@ -45,6 +45,7 @@
       "fileVersion": "file_version",
       "urls": "urls",
       "dosUrl": "dosUrl",
+      "aliases": "aliases",
       "lastModified": "lastModified",
       "repoBaseUrl": "repoBaseUrl",
       "repoCode": "repoCode",

--- a/config/request_config.json
+++ b/config/request_config.json
@@ -35,7 +35,8 @@
     "Upload File ID": "file_id",
     "Data Bundle UUID": "repoDataBundleId",
     "Metadata.json": "metadataJson",
-    "File URLs": "urls"
+    "File URLs": "urls",
+    "File Aliases": "aliases"
   },
   "autocomplete-translation": {
     "ES_FILE_INDEX": {
@@ -99,7 +100,8 @@
     "Upload File ID",
     "Data Bundle UUID",
     "Metadata.json",
-    "File URLs"
+    "File URLs",
+    "File Aliases"
   ],
   "facets": [
     "centerName",

--- a/responseobjects/api_response.py
+++ b/responseobjects/api_response.py
@@ -34,6 +34,7 @@ class FileCopyObj(JsonObject):
     fileVersion = StringProperty()
     urls = ListProperty(StringProperty)
     dosUri = StringProperty()
+    aliases = ListProperty(StringProperty)
     # DateTimeProperty Int given the ICGC format uses
     # an int and not DateTimeProperty
     lastModified = StringProperty()
@@ -454,6 +455,7 @@ class KeywordSearchResponse(AbstractResponse, EntryFetcher):
             urls=self.fetch_entry_value(mapping, entry, 'urls'),
             dosUri=self.compose_dos_uri(self.fetch_entry_value(mapping, entry, 'fileId'),
                                         self.fetch_entry_value(mapping, entry, 'fileVersion')),
+            aliases=self.fetch_entry_value(mapping, entry, 'aliases'),
             lastModified=self.fetch_entry_value(
                 mapping, entry, 'lastModified')
         )


### PR DESCRIPTION
The "aliases" field was added to present GUIDs and/or other alternate file identifiers.
This enables inclusion of the "aliases" field in both the manifest and the (Boardwalk) UI.