### PR TITLE
Feature/fix column 107

### DIFF
--- a/bagitutils.py
+++ b/bagitutils.py
@@ -15,11 +15,11 @@ class BoardwalkColumns:
     def __init__(self):
         pass
 
+    # Special columns.
     SAMPLE_UUID = 'Sample UUID'
     DONOR_UUID = 'Donor UUID'
     FILE_TYPE = 'File Type'
     FILE_URLS = 'File URLs'
-    SPECIMEN_UUID = 'Specimen UUID'
     FILE_DOS_URI = 'File DOS URI'
     FILE_PATH = 'File Path'
     UPLOAD_FILE_ID = 'Upload File ID'
@@ -194,16 +194,16 @@ class BagHandler:
         reader = csv.DictReader(StringIO(self.data), delimiter='\t')
         participants = set()
         native_protocols = set()
-        specimens = {}  # key: specimen UUID, value count
+        samples = {}  # key: samples UUID, value count
         for row in reader:
             # Add all participants. It's a set, so no dupes
             participants.add(row[BoardwalkColumns.DONOR_UUID])
 
-            specimen_uuid = row[BoardwalkColumns.SPECIMEN_UUID]
-            if specimen_uuid in specimens:
-                specimens[specimen_uuid] = specimens[specimen_uuid] + 1
+            sample_uuid = row[BoardwalkColumns.SAMPLE_UUID]
+            if sample_uuid in samples:
+                samples[sample_uuid] = samples[sample_uuid] + 1
             else:
-                specimens[specimen_uuid] = 1
+                samples[sample_uuid] = 1
 
             # Track all the different cloud native url protocols
             for file_url in row[BoardwalkColumns.FILE_URLS].split(','):
@@ -211,7 +211,7 @@ class BagHandler:
                 if protocol is not None:
                     native_protocols.add(protocol)
 
-        return participants, max(specimens.values()), native_protocols
+        return participants, max(samples.values()), native_protocols
 
     def samples(self, max_files_in_sample, native_protocols):
         """
@@ -232,14 +232,14 @@ class BagHandler:
         reader = csv.DictReader(StringIO(self.data), delimiter='\t')
         samples = []
 
-        current_specimen_uuid = None
+        current_sample_uuid = None
         current_row = None
 
         for row in sorted(reader, key=operator.itemgetter(
-                BoardwalkColumns.SPECIMEN_UUID)):
-            specimen_uuid = row[BoardwalkColumns.SPECIMEN_UUID]
-            if specimen_uuid != current_specimen_uuid:
-                current_specimen_uuid = specimen_uuid
+                BoardwalkColumns.SAMPLE_UUID)):
+            sample_uuid = row[BoardwalkColumns.SAMPLE_UUID]
+            if sample_uuid != current_sample_uuid:
+                current_sample_uuid = sample_uuid
                 index = 1
                 if current_row is not None:
                     samples.append(current_row)

--- a/bagitutils.py
+++ b/bagitutils.py
@@ -37,6 +37,7 @@ FILE_COLUMNS = [
 # Column names in Boardwalk that cannot simply be copied over to FireCloud;
 # they require extra logic.
 COMPLEX_COLUMNS = FILE_COLUMNS + [
+    BoardwalkColumns.DONOR_UUID,
     BoardwalkColumns.SAMPLE_UUID,
     BoardwalkColumns.FILE_URLS
 ]
@@ -55,7 +56,7 @@ class RequiredFirecloudColumns:
 
     # Columns in sample.tsv
     SAMPLE_SAMPLE_ID = 'entity:sample_id'
-    SAMPLE_PARTICIPANT = 'participant'
+    SAMPLE_PARTICIPANT = 'participant_id'
 
 
 class BagHandler:
@@ -142,9 +143,9 @@ class BagHandler:
         # zip_fh is zipfile handle
         path_length = len(path)
         for root, dirs, files in os.walk(path):
-            for file in files:
-                zip_fh.write(os.path.join(root, file),
-                             arcname=root[path_length:] + '/' + file)
+            for _file in files:
+                zip_fh.write(os.path.join(root, _file),
+                             arcname=root[path_length:] + '/' + _file)
 
     def write_csv_files(self, data_path):
         """
@@ -169,10 +170,14 @@ class BagHandler:
                 if first_row:
                     first_row = False
                     keys = sample.keys()
-                    # entity:sample_id must be first
+                    # entity:sample_id must be first. For convenience, we
+                    # add participant_id second.
                     keys.remove(RequiredFirecloudColumns.SAMPLE_SAMPLE_ID)
-                    fieldnames = [ RequiredFirecloudColumns.SAMPLE_SAMPLE_ID]\
-                                 + sorted(keys)
+                    keys.remove(RequiredFirecloudColumns.SAMPLE_PARTICIPANT)
+                    fieldnames = (
+                        [RequiredFirecloudColumns.SAMPLE_SAMPLE_ID] +
+                        [RequiredFirecloudColumns.SAMPLE_PARTICIPANT] +
+                        sorted(keys))
                     writer = csv.DictWriter(tsv, fieldnames=fieldnames,
                                             delimiter='\t')
                     writer.writeheader()
@@ -215,10 +220,13 @@ class BagHandler:
 
     def samples(self, max_files_in_sample, native_protocols):
         """
-        Creates a list of dicts, dict is a row in the sample TSV for FireCloud.
-        For all rows of the same sample in the input, create one row only,
-        where the file-specific data from each row is appended as additional
-        columns to the one row.
+        Creates a list of dicts, where one dict is a row in the sample TSV 
+        for FireCloud. For all rows of the same sample in the input create 
+        one row only, where the file-specific data from each row is 
+        appended as additional columns to the one row (reasons
+        for having multiple rows of the same sample are for instance 
+        different file types or different cloud storage protocols for a given
+        sample ID).
 
         The input is self.data. Requires that data be sorted by
         BoardwalkColumns.SAMPLE_UUID; this routine sorts it. If data could be
@@ -234,9 +242,10 @@ class BagHandler:
 
         current_sample_uuid = None
         current_row = None
+        index = None
 
         for row in sorted(reader, key=operator.itemgetter(
-                BoardwalkColumns.SAMPLE_UUID)):
+                BoardwalkColumns.SAMPLE_UUID)):  # sort by sample ID
             sample_uuid = row[BoardwalkColumns.SAMPLE_UUID]
             if sample_uuid != current_sample_uuid:
                 current_sample_uuid = sample_uuid
@@ -272,30 +281,30 @@ class BagHandler:
         for column in FILE_COLUMNS:
             if column in existing_row:
                 new_row[self.firecloud_column_name(column) + suffix] = \
-                existing_row[column]
+                    existing_row[column]
 
     def init_sample_row(self, existing_row, max_files_in_sample,
                         native_protocols):
         """
         Create and initialize a sample row
         :param existing_row: the existing row
-        :param max_files_in_sample: the maximum number of files in a sample
+        :param max_files_in_sample: maximum number of file types of any sample
         :param native_protocols:
         :return: the initialized row
         """
-        # Rename sample column and participant
+        # Rename sample column and participant.
         row = {RequiredFirecloudColumns.SAMPLE_SAMPLE_ID: existing_row[
             BoardwalkColumns.SAMPLE_UUID],
                RequiredFirecloudColumns.SAMPLE_PARTICIPANT: existing_row[
                    BoardwalkColumns.DONOR_UUID]}
 
         # Copy rows that don't need transformation, other than FC naming
-        # conventions
+        # conventions.
         for key, value in existing_row.iteritems():
             if key not in COMPLEX_COLUMNS:
                 row[self.firecloud_column_name(key)] = value
 
-        # Initialize columns for files and cloud native urls
+        # Initialize columns for files and cloud native urls.
         for suffix in [str(i) for i in range(1, max_files_in_sample + 1)]:
             for column in FILE_COLUMNS:
                 row[self.firecloud_column_name(column) + suffix] = None

--- a/test/fc_mock.tsv
+++ b/test/fc_mock.tsv
@@ -1,0 +1,9 @@
+Donor UUID	Sample UUID	File Type	Specimen UUID	File URLs
+d1	s1	crai	sp1	gs://junk.crai
+d1	s1	cram	sp1	gs://junk.cram
+d1	s2	crai	sp1	s3://junk.crai
+d1	s2	cram	sp1	s3://junk.cram
+d2	s3	crai	sp1	gs://junk.crai
+d2	s3	cram	sp1	gs://junk.cram
+d3	s4	crai	sp1	gs://junk.crai
+d3	s4	cram	sp1	gs://junk.cram

--- a/test/fc_mock.tsv
+++ b/test/fc_mock.tsv
@@ -7,3 +7,7 @@ d2	s3	crai	sp1	gs://junk.crai
 d2	s3	cram	sp1	gs://junk.cram
 d3	s4	crai	sp1	gs://junk.crai
 d3	s4	cram	sp1	gs://junk.cram
+d4	s5	crai	sp2	gs://junk.crai
+d4	s5	cram	sp2	gs://junk.cram
+d4	s5	bam	sp2	gs://junk.bam
+d5	s6	crai	sp3	gs://junk.crai

--- a/test/manifest_bag/participant.tsv
+++ b/test/manifest_bag/participant.tsv
@@ -1,6 +1,0 @@
-entity:participant_id
-d4
-d5
-d2
-d3
-d1

--- a/test/manifest_bag/participant.tsv
+++ b/test/manifest_bag/participant.tsv
@@ -1,0 +1,6 @@
+entity:participant_id
+d4
+d5
+d2
+d3
+d1

--- a/test/manifest_bag/sample.tsv
+++ b/test/manifest_bag/sample.tsv
@@ -1,0 +1,7 @@
+entity:sample_id	participant_id	file_dos_uri1	file_dos_uri2	file_dos_uri3	file_path1	file_path2	file_path3	file_type1	file_type2	file_type3	gs_url1	gs_url2	gs_url3	s3_url1	s3_url2	s3_url3	specimen_uuid	upload_file_id1	upload_file_id2	upload_file_id3
+s1	d1							crai	cram		gs://junk.crai	gs://junk.cram					sp1			
+s2	d1							crai	cram					s3://junk.crai	s3://junk.cram		sp1			
+s3	d2							crai	cram		gs://junk.crai	gs://junk.cram					sp1			
+s4	d3							crai	cram		gs://junk.crai	gs://junk.cram					sp1			
+s5	d4							crai	cram	bam	gs://junk.crai	gs://junk.cram	gs://junk.bam				sp2			
+s6	d5							crai			gs://junk.crai						sp3			

--- a/test/manifest_bag/sample.tsv
+++ b/test/manifest_bag/sample.tsv
@@ -1,7 +1,0 @@
-entity:sample_id	participant_id	file_dos_uri1	file_dos_uri2	file_dos_uri3	file_path1	file_path2	file_path3	file_type1	file_type2	file_type3	gs_url1	gs_url2	gs_url3	s3_url1	s3_url2	s3_url3	specimen_uuid	upload_file_id1	upload_file_id2	upload_file_id3
-s1	d1							crai	cram		gs://junk.crai	gs://junk.cram					sp1			
-s2	d1							crai	cram					s3://junk.crai	s3://junk.cram		sp1			
-s3	d2							crai	cram		gs://junk.crai	gs://junk.cram					sp1			
-s4	d3							crai	cram		gs://junk.crai	gs://junk.cram					sp1			
-s5	d4							crai	cram	bam	gs://junk.crai	gs://junk.cram	gs://junk.bam				sp2			
-s6	d5							crai			gs://junk.crai						sp3			

--- a/test/test_bagitutils.py
+++ b/test/test_bagitutils.py
@@ -81,16 +81,16 @@ NIH Data Commons	NIH Data Commons Pilot	Broad Public Datasets	ABC123456	c2b4c298
         """Tests a mock file with a minimal set of columns."""
         mock_simple = 'test/fc_mock.tsv'
         real107 = '/home/michael/dev/manifest-handover/manifests/manifest_107_genomes.tsv'
-        with open(real107, 'r') as tsv:
+        with open(mock_simple, 'r') as tsv:
             lines = tsv.readlines()
         data = "\n".join(lines)
         bag = BagHandler(data=data, bag_info={}, bag_name='manifest')
         participants, max_files_in_sample, protocols = bag.participants_and_max_files_in_sample_and_protocols()
-        # self.assertEqual(len(participants), 2)
-        # self.assertEqual(len(protocols), 1)
-        # self.assertEqual(max_files_in_sample, 4)
+        self.assertEqual(len(participants), 2)
+        self.assertEqual(len(protocols), 1)
+        self.assertEqual(max_files_in_sample, 2)
         samples = bag.samples(max_files_in_sample, protocols)
-        # self.assertEqual(len(samples), 1)
+        self.assertEqual(len(samples), 2)
 
         print(bag.data)
         data_path = '/home/michael/dev/manifest-handover/test_107'


### PR DESCRIPTION
This PR fixes a small bug that caused an incorrect assembly of `samples.tsv`. In particular, it
created too many columns.
* added unit test which tests a small mock TSV file that should cover all use cases
* added 'Donor UUID' to COMPLEX columns so its name can be overwritten by the FireCloud compliant participant_ID
* added / changed a couple of comments